### PR TITLE
Added Hub.unsubscribe_and_flush, 178

### DIFF
--- a/lib/hub.ex
+++ b/lib/hub.ex
@@ -19,6 +19,7 @@ defmodule Hub do
   Unsubscribes using the reference returned on subscribe
   """
   defdelegate unsubscribe(ref), to: Channel
+  defdelegate unsubscribe_and_flush(ref), to: Channel
 
   @doc """
   Convenience macro for subscribing without the need to unquote the pattern.


### PR DESCRIPTION
Closes #178 

Can now `unsubscribe_and_flush` to avoid message leaking in race conditions.